### PR TITLE
adjust luck ranking and playoff probabilities calculations

### DIFF
--- a/calculate/covid_risk.py
+++ b/calculate/covid_risk.py
@@ -64,7 +64,7 @@ class CovidRisk(object):
             "Seattle Seahawks": "SEA",
             "Tampa Bay Buccaneers": "TB",
             "Tennessee Titans": "TEN",
-            "Washington Football Team": "WAS"
+            "Washington Commanders": "WAS"
         }
 
         # nfl team abbreviations

--- a/calculate/metrics.py
+++ b/calculate/metrics.py
@@ -77,9 +77,9 @@ class CalculateMetrics(object):
                     x.record.get_wins(),
                     -x.record.get_losses(),
                     x.record.get_ties(),
-                    x.record.get_division_wins(),
-                    -x.record.get_division_losses(),
-                    x.record.get_division_ties(),
+                    # x.record.get_division_wins(),
+                    # -x.record.get_division_losses(),
+                    # x.record.get_division_ties(),
                     float(x.record.get_points_for())
                 ),
                 reverse=True
@@ -812,7 +812,7 @@ class CalculateMetrics(object):
         for team_rankings in power_ranked_teams.values():
             team_rankings["power_ranking"] = (team_rankings["score_ranking"] +
                                               team_rankings["coaching_efficiency_ranking"] +
-                                              team_rankings["luck_ranking"]) // 3.0
+                                              team_rankings["luck_ranking"]) / 3.0
         return power_ranked_teams
 
     @staticmethod

--- a/calculate/playoff_probabilities.py
+++ b/calculate/playoff_probabilities.py
@@ -32,7 +32,7 @@ class PlayoffProbabilities(object):
         self.num_weeks = int(num_weeks)
         self.num_playoff_slots = int(num_playoff_slots)
         self.data_dir = data_dir
-        self.num_divisions = num_divisions
+        self.num_divisions = 0
         self.save_data = save_data
         self.recalculate = recalculate
         self.dev_offline = dev_offline

--- a/dao/platforms/espn.py
+++ b/dao/platforms/espn.py
@@ -466,7 +466,7 @@ class LeagueData(object):
                         #  Washington Football Team
                         # base_player.first_name = player_json["firstName"]
                         base_player.first_name = player_json["firstName"] if player_json["firstName"] != "Washington" \
-                            else "Football Team"
+                            else "Commanders"
                         base_player.full_name = base_player.first_name
                         base_player.nfl_team_name = base_player.first_name
                         base_player.headshot_url = \


### PR DESCRIPTION
fix issues with calculate scripts: Washington Football Team to Washington Commanders, remove floor division from luck ranking when using it to calculate power rankings, and take out division calculations in playoff probabilities